### PR TITLE
build: removing SHAPSHOT tag from jrejson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<dependency>
 			<groupId>com.redislabs</groupId>
 			<artifactId>jrejson</artifactId>
-			<version>1.4.0-SNAPSHOT</version>
+			<version>1.4.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.redislabs</groupId>


### PR DESCRIPTION
Removing `-SNAPSHOT` tag from jrejson - this was stopping this app from building for me as it couldn't be found in mavencentral